### PR TITLE
Feature/#1 축제 상세 페이지, 축제 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/acc/somsomparty/domain/Festival/controller/FestivalController.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/controller/FestivalController.java
@@ -1,0 +1,31 @@
+package com.acc.somsomparty.domain.Festival.controller;
+
+import com.acc.somsomparty.domain.Festival.converter.FestivalConverter;
+import com.acc.somsomparty.domain.Festival.dto.FestivalResponseDTO;
+import com.acc.somsomparty.domain.Festival.entity.Festival;
+
+import com.acc.somsomparty.domain.Festival.service.FestivalQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/festivals")
+@RequiredArgsConstructor
+public class FestivalController {
+    private final FestivalQueryService festivalQueryService;
+
+    @GetMapping("")
+    public ResponseEntity<FestivalResponseDTO.FestivalPreViewListDTO> getFestivalList(@RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
+        FestivalResponseDTO.FestivalPreViewListDTO festivalPage = festivalQueryService.getFestivalList(lastId, limit);
+        return new ResponseEntity<>(festivalPage, HttpStatus.OK);
+    }
+
+    @GetMapping("/{festivalId}")
+    public ResponseEntity<FestivalResponseDTO.FestivalPreViewDTO> getFestival(@PathVariable(name = "festivalId") Long festivalId) {
+        Festival festival = festivalQueryService.getFestival(festivalId);
+        return new ResponseEntity<>(FestivalConverter.festivalPreViewDTO(festival), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Festival/converter/FestivalConverter.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/converter/FestivalConverter.java
@@ -1,0 +1,26 @@
+package com.acc.somsomparty.domain.Festival.converter;
+
+import com.acc.somsomparty.domain.Festival.dto.FestivalResponseDTO;
+import com.acc.somsomparty.domain.Festival.entity.Festival;
+
+import java.util.List;
+
+public class FestivalConverter {
+    public static FestivalResponseDTO.FestivalPreViewDTO festivalPreViewDTO(Festival festival) {
+        return FestivalResponseDTO.FestivalPreViewDTO.builder()
+                .id(festival.getId())
+                .name(festival.getName())
+                .description(festival.getDescription())
+                .startDate(festival.getStartDate())
+                .endDate(festival.getEndDate())
+                .build();
+    }
+
+    public static FestivalResponseDTO.FestivalPreViewListDTO festivalPreViewListDTO(List<FestivalResponseDTO.FestivalPreViewDTO> festivals, boolean hasNext, Long lastId) {
+        return FestivalResponseDTO.FestivalPreViewListDTO.builder()
+                .festivals(festivals)
+                .hasNext(hasNext)
+                .lastId(lastId)
+                .build();
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Festival/dto/FestivalResponseDTO.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/dto/FestivalResponseDTO.java
@@ -1,0 +1,33 @@
+package com.acc.somsomparty.domain.Festival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class FestivalResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FestivalPreViewDTO {
+        Long id;
+        String name;
+        String description;
+        LocalDate startDate;
+        LocalDate endDate;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FestivalPreViewListDTO {
+        List<FestivalResponseDTO.FestivalPreViewDTO> festivals;
+        boolean hasNext;
+        Long lastId;
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Festival/entity/Festival.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/entity/Festival.java
@@ -1,6 +1,7 @@
 package com.acc.somsomparty.domain.Festival.entity;
 
 import com.acc.somsomparty.domain.Reservation.entity.Reservation;
+import com.acc.somsomparty.domain.Ticket.entity.Ticket;
 import com.acc.somsomparty.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -22,11 +23,12 @@ public class Festival extends BaseEntity {
     private String name;
     @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
-    private Integer maxCapacity;
-    @Column(name = "start_date", nullable = false, columnDefinition = "DATETIME(0)")
+    @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
-    @Column(name = "end_date", nullable = false, columnDefinition = "DATETIME(0)")
+    @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
     @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL)
     private List<Reservation> reservationList = new ArrayList<>();
+    @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL)
+    private List<Ticket> ticketList = new ArrayList<>();
 }

--- a/src/main/java/com/acc/somsomparty/domain/Festival/repository/FestivalRepository.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/repository/FestivalRepository.java
@@ -1,0 +1,13 @@
+package com.acc.somsomparty.domain.Festival.repository;
+
+import com.acc.somsomparty.domain.Festival.entity.Festival;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface FestivalRepository extends JpaRepository<Festival, Long> {
+    Page<Festival> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<Festival> findByCreatedAtLessThanOrderByCreatedAtDesc(LocalDateTime createdAt, Pageable pageable);
+}

--- a/src/main/java/com/acc/somsomparty/domain/Festival/service/FestivalQueryService.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/service/FestivalQueryService.java
@@ -1,0 +1,10 @@
+package com.acc.somsomparty.domain.Festival.service;
+
+
+import com.acc.somsomparty.domain.Festival.dto.FestivalResponseDTO;
+import com.acc.somsomparty.domain.Festival.entity.Festival;
+
+public interface FestivalQueryService {
+    FestivalResponseDTO.FestivalPreViewListDTO getFestivalList(Long lastId, int offset);
+    Festival getFestival(Long festivalId);
+}

--- a/src/main/java/com/acc/somsomparty/domain/Festival/service/FestivalQueryServiceImpl.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/service/FestivalQueryServiceImpl.java
@@ -1,0 +1,55 @@
+package com.acc.somsomparty.domain.Festival.service;
+
+import com.acc.somsomparty.domain.Festival.converter.FestivalConverter;
+import com.acc.somsomparty.domain.Festival.dto.FestivalResponseDTO;
+import com.acc.somsomparty.domain.Festival.entity.Festival;
+import com.acc.somsomparty.domain.Festival.repository.FestivalRepository;
+import com.acc.somsomparty.global.exception.CustomException;
+import com.acc.somsomparty.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class FestivalQueryServiceImpl implements FestivalQueryService {
+    private final FestivalRepository festivalRepository;
+
+    @Override
+    public FestivalResponseDTO.FestivalPreViewListDTO getFestivalList(Long lastId, int limit) {
+        List<Festival> result;
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        if (lastId.equals(0L)) {
+            result = festivalRepository.findAllByOrderByCreatedAtDesc(pageRequest).getContent();
+        }
+        else {
+            Festival festival = festivalRepository.findById(lastId).orElseThrow(() -> new CustomException(ErrorCode.FESTIVAL_NOT_FOUND));
+            result = festivalRepository.findByCreatedAtLessThanOrderByCreatedAtDesc(festival.getCreatedAt(), pageRequest).getContent();
+        }
+        return generateFestivalPreviewListDTO(result, limit);
+    }
+
+    @Override
+    public Festival getFestival(Long festivalId) {
+        return festivalRepository.findById(festivalId).orElseThrow(() -> new CustomException(ErrorCode.FESTIVAL_NOT_FOUND));
+    }
+
+    private FestivalResponseDTO.FestivalPreViewListDTO generateFestivalPreviewListDTO(List<Festival> festivals, int limit) {
+        boolean hasNext = festivals.size() > limit;
+        Long lastId = null;
+        if (hasNext) {
+            festivals = festivals.subList(0, festivals.size() - 1); // 마지막 항목 제외
+            lastId = festivals.get(festivals.size() - 1).getId(); // 마지막 항목의 ID를 커서로 설정
+        }
+        List<FestivalResponseDTO.FestivalPreViewDTO> list = festivals
+                .stream()
+                .map(FestivalConverter::festivalPreViewDTO)
+                .collect(Collectors.toList());
+
+        return FestivalConverter.festivalPreViewListDTO(list, hasNext, lastId);
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/entity/Reservation.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/entity/Reservation.java
@@ -1,6 +1,8 @@
 package com.acc.somsomparty.domain.Reservation.entity;
 
+import com.acc.somsomparty.domain.Festival.entity.Festival;
 import com.acc.somsomparty.domain.Festival.enums.ReservationStatus;
+import com.acc.somsomparty.domain.User.entity.User;
 import com.acc.somsomparty.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -16,14 +18,14 @@ public class Reservation extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(name = "festival_id")
-    private Long festivalId;
-    @Column(name = "user_id")
-    private Long userId;
-    @Column(name = "reservation_date", nullable = false, columnDefinition = "DATETIME(0)")
+    @ManyToOne
+    @JoinColumn(name = "festival_id")
+    private Festival festival;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+    @Column(name = "reservation_date", nullable = false)
     private LocalDate reservationDate;
     @Enumerated(EnumType.STRING)
     private ReservationStatus reservationStatus;
-    @Column(name = "reservation_count", nullable = false)
-    private Integer reservationCount;
 }

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/entity/Reservation.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/entity/Reservation.java
@@ -1,7 +1,7 @@
 package com.acc.somsomparty.domain.Reservation.entity;
 
 import com.acc.somsomparty.domain.Festival.entity.Festival;
-import com.acc.somsomparty.domain.Festival.enums.ReservationStatus;
+import com.acc.somsomparty.domain.Reservation.enums.ReservationStatus;
 import com.acc.somsomparty.domain.User.entity.User;
 import com.acc.somsomparty.global.common.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/enums/ReservationStatus.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/enums/ReservationStatus.java
@@ -1,4 +1,4 @@
-package com.acc.somsomparty.domain.Festival.enums;
+package com.acc.somsomparty.domain.Reservation.enums;
 
 public enum ReservationStatus {
     PENDING, CONFIRMED, COMPLETED

--- a/src/main/java/com/acc/somsomparty/domain/User/entity/User.java
+++ b/src/main/java/com/acc/somsomparty/domain/User/entity/User.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(name = "user")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/acc/somsomparty/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/acc/somsomparty/global/exception/error/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
-    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다.");
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    // Festival
+    FESTIVAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 축제입니다.");
 
     private final HttpStatus httpStatus;    // HttpStatus
     private final String message;       // 설명


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #1

## 📝 작업 내용
-  Festival, Reservation 간 연관관계 에러를 해결했습니다.
- 축제 상세 페이지, 축제 목록 조회 API를 구현했습니다.

## 💬 리뷰 요구사항
> API 구현한 거 전체적으로 봐주셨으면 합니다!