### PR TITLE
Feature/#11 예약 API 구현

### DIFF
--- a/src/main/java/com/acc/somsomparty/domain/Queue/service/UserQueueService.java
+++ b/src/main/java/com/acc/somsomparty/domain/Queue/service/UserQueueService.java
@@ -1,7 +1,6 @@
 package com.acc.somsomparty.domain.Queue.service;
 
 import com.acc.somsomparty.domain.Queue.config.SqsSender;
-import com.acc.somsomparty.global.common.aspect.DistributedLock;
 import com.acc.somsomparty.global.exception.CustomException;
 import com.acc.somsomparty.global.exception.error.ErrorCode;
 import io.awspring.cloud.sqs.annotation.SqsListener;

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/controller/ReservationController.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/controller/ReservationController.java
@@ -1,0 +1,33 @@
+package com.acc.somsomparty.domain.Reservation.controller;
+
+import com.acc.somsomparty.domain.Reservation.dto.ReservationRequestDTO;
+import com.acc.somsomparty.domain.Reservation.dto.ReservationResponseDTO;
+import com.acc.somsomparty.domain.Reservation.service.ReservationCommandService;
+import com.acc.somsomparty.domain.Reservation.service.ReservationQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+    private final ReservationQueryService reservationQueryService;
+    private final ReservationCommandService reservationCommandService;
+
+    @Operation(summary = "예약 목록 조회", description = "사용자의 예약 목록을 조회합니다.")
+    @GetMapping("")
+    public ResponseEntity<ReservationResponseDTO.ReservationPreViewListDTO> getReservationList(@RequestParam(name = "userId") Long userId, @RequestParam(defaultValue = "0") Long lastId, @RequestParam(defaultValue = "10") int limit) {
+        ReservationResponseDTO.ReservationPreViewListDTO reservationPage = reservationQueryService.getReservationList(userId, lastId, limit);
+        return new ResponseEntity<>(reservationPage, HttpStatus.OK);
+    }
+
+    @Operation(summary = "예약하기", description = "사용자 정보와 예약 날짜로 예약합니다.")
+    @PostMapping("")
+    public ResponseEntity<ReservationResponseDTO.makeReservationResultDTO> makeReservation(@RequestBody ReservationRequestDTO.makeReservationDTO request) {
+        ReservationResponseDTO.makeReservationResultDTO reservationResultDTO = reservationCommandService.makeReservation(request);
+        return new ResponseEntity<>(reservationResultDTO, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/converter/ReservationConverter.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/converter/ReservationConverter.java
@@ -1,0 +1,44 @@
+package com.acc.somsomparty.domain.Reservation.converter;
+
+import com.acc.somsomparty.domain.Festival.converter.FestivalConverter;
+import com.acc.somsomparty.domain.Reservation.dto.ReservationResponseDTO;
+import com.acc.somsomparty.domain.Reservation.entity.Reservation;
+import com.acc.somsomparty.domain.Ticket.entity.Ticket;
+import com.acc.somsomparty.domain.User.entity.User;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ReservationConverter {
+    public static ReservationResponseDTO.ReservationPreViewDTO reservationPreViewDTO(Reservation reservation) {
+        return ReservationResponseDTO.ReservationPreViewDTO.builder()
+                .id(reservation.getId())
+                .reservationDate(reservation.getReservationDate())
+                .festivalInfo(FestivalConverter.festivalPreViewDTO(reservation.getTicket().getFestival()))
+                .build();
+    }
+
+    public static ReservationResponseDTO.ReservationPreViewListDTO reservationPreViewListDTO(List<ReservationResponseDTO.ReservationPreViewDTO> reservations, boolean hasNext, Long lastId) {
+        return ReservationResponseDTO.ReservationPreViewListDTO.builder()
+                .reservations(reservations)
+                .hasNext(hasNext)
+                .lastId(lastId)
+                .build();
+    }
+
+    public static Reservation toReservation(User user, Ticket ticket) {
+        return Reservation.builder()
+                .user(user)
+                .reservationDate(LocalDate.now())
+                .ticket(ticket)
+                .build();
+    }
+
+    public static ReservationResponseDTO.makeReservationResultDTO makeReservationResultDTO(Reservation reservation) {
+        return ReservationResponseDTO.makeReservationResultDTO.builder()
+                .reservationId(reservation.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/dto/ReservationRequestDTO.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/dto/ReservationRequestDTO.java
@@ -1,0 +1,16 @@
+package com.acc.somsomparty.domain.Reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class ReservationRequestDTO {
+    @Getter
+    @Builder
+    public static class makeReservationDTO {
+        Long userId;
+        Long festivalId;
+        LocalDate festivalDate;
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/dto/ReservationResponseDTO.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/dto/ReservationResponseDTO.java
@@ -1,0 +1,42 @@
+package com.acc.somsomparty.domain.Reservation.dto;
+
+import com.acc.somsomparty.domain.Festival.dto.FestivalResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ReservationResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReservationPreViewDTO {
+        Long id;
+        LocalDate reservationDate;
+        FestivalResponseDTO.FestivalPreViewDTO festivalInfo;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReservationPreViewListDTO {
+        List<ReservationResponseDTO.ReservationPreViewDTO> reservations;
+        boolean hasNext;
+        Long lastId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class makeReservationResultDTO {
+        Long reservationId;
+        LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/entity/Reservation.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/entity/Reservation.java
@@ -1,7 +1,6 @@
 package com.acc.somsomparty.domain.Reservation.entity;
 
-import com.acc.somsomparty.domain.Festival.entity.Festival;
-import com.acc.somsomparty.domain.Reservation.enums.ReservationStatus;
+import com.acc.somsomparty.domain.Ticket.entity.Ticket;
 import com.acc.somsomparty.domain.User.entity.User;
 import com.acc.somsomparty.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -19,13 +18,12 @@ public class Reservation extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
-    @JoinColumn(name = "festival_id")
-    private Festival festival;
+    @JoinColumn(name = "ticket_id")
+    private Ticket ticket;
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
     @Column(name = "reservation_date", nullable = false)
     private LocalDate reservationDate;
-    @Enumerated(EnumType.STRING)
-    private ReservationStatus reservationStatus;
 }
+

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/enums/ReservationStatus.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/enums/ReservationStatus.java
@@ -1,5 +1,0 @@
-package com.acc.somsomparty.domain.Reservation.enums;
-
-public enum ReservationStatus {
-    PENDING, CONFIRMED, COMPLETED
-}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/repository/ReservationRepository.java
@@ -1,0 +1,13 @@
+package com.acc.somsomparty.domain.Reservation.repository;
+
+import com.acc.somsomparty.domain.Reservation.entity.Reservation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    Page<Reservation> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    Page<Reservation> findByUserIdAndCreatedAtLessThanOrderByCreatedAtDesc(Long userId, LocalDateTime createdAt, Pageable pageable);
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/service/ReservationCommandService.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/service/ReservationCommandService.java
@@ -1,0 +1,8 @@
+package com.acc.somsomparty.domain.Reservation.service;
+
+import com.acc.somsomparty.domain.Reservation.dto.ReservationRequestDTO;
+import com.acc.somsomparty.domain.Reservation.dto.ReservationResponseDTO;
+
+public interface ReservationCommandService {
+    ReservationResponseDTO.makeReservationResultDTO makeReservation(ReservationRequestDTO.makeReservationDTO request);
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/service/ReservationCommandServiceImpl.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/service/ReservationCommandServiceImpl.java
@@ -1,0 +1,41 @@
+package com.acc.somsomparty.domain.Reservation.service;
+
+import com.acc.somsomparty.domain.Reservation.converter.ReservationConverter;
+import com.acc.somsomparty.domain.Reservation.dto.ReservationRequestDTO;
+import com.acc.somsomparty.domain.Reservation.dto.ReservationResponseDTO;
+import com.acc.somsomparty.domain.Reservation.entity.Reservation;
+import com.acc.somsomparty.domain.Reservation.repository.ReservationRepository;
+import com.acc.somsomparty.domain.Ticket.entity.Ticket;
+import com.acc.somsomparty.domain.Ticket.repository.TicketRepository;
+import com.acc.somsomparty.domain.User.entity.User;
+import com.acc.somsomparty.domain.User.repository.UserRepository;
+import com.acc.somsomparty.global.exception.CustomException;
+import com.acc.somsomparty.global.exception.error.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationCommandServiceImpl implements ReservationCommandService{
+    private final TicketRepository ticketRepository;
+    private final UserRepository userRepository;
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    @Transactional
+    public ReservationResponseDTO.makeReservationResultDTO makeReservation(ReservationRequestDTO.makeReservationDTO request) {
+        Ticket ticket = ticketRepository.findByFestivalIdAndFestivalDateWithLock(request.getFestivalId(), request.getFestivalDate()).orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
+        User user = userRepository.findById(request.getUserId()).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if(ticket.getLeftTickets() >= 1) {
+            ticket.setLeftTickets(ticket.getLeftTickets() - 1);
+            ticketRepository.save(ticket);
+            Reservation reservation = ReservationConverter.toReservation(user, ticket);
+            reservationRepository.saveAndFlush(reservation);
+            return ReservationConverter.makeReservationResultDTO(reservation);
+        }
+        // 만약 남은 티켓 수가 0이면 예외를 던짐
+        throw new CustomException(ErrorCode.TICKET_SOLD_OUT);
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/service/ReservationQueryService.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/service/ReservationQueryService.java
@@ -1,0 +1,7 @@
+package com.acc.somsomparty.domain.Reservation.service;
+
+import com.acc.somsomparty.domain.Reservation.dto.ReservationResponseDTO;
+
+public interface ReservationQueryService {
+    ReservationResponseDTO.ReservationPreViewListDTO getReservationList(Long userId, Long lastId, int offset);
+}

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/service/ReservationQueryServiceImpl.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/service/ReservationQueryServiceImpl.java
@@ -1,0 +1,49 @@
+package com.acc.somsomparty.domain.Reservation.service;
+
+import com.acc.somsomparty.domain.Reservation.converter.ReservationConverter;
+import com.acc.somsomparty.domain.Reservation.dto.ReservationResponseDTO;
+import com.acc.somsomparty.domain.Reservation.entity.Reservation;
+import com.acc.somsomparty.domain.Reservation.repository.ReservationRepository;
+import com.acc.somsomparty.global.exception.CustomException;
+import com.acc.somsomparty.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationQueryServiceImpl implements ReservationQueryService {
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public ReservationResponseDTO.ReservationPreViewListDTO getReservationList(Long userId, Long lastId, int limit) {
+        List<Reservation> result;
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        if (lastId.equals(0L)) {
+            result = reservationRepository.findAllByUserIdOrderByCreatedAtDesc(userId, pageRequest).getContent();
+        }
+        else {
+            Reservation reservation = reservationRepository.findById(lastId).orElseThrow(() -> new CustomException(ErrorCode.FESTIVAL_NOT_FOUND));
+            result = reservationRepository.findByUserIdAndCreatedAtLessThanOrderByCreatedAtDesc(userId, reservation.getCreatedAt(), pageRequest).getContent();
+        }
+        return generateReservationPreviewListDTO(result, limit);
+    }
+
+    private ReservationResponseDTO.ReservationPreViewListDTO generateReservationPreviewListDTO(List<Reservation> reservations, int limit) {
+        boolean hasNext = reservations.size() > limit;
+        Long lastId = null;
+        if (hasNext) {
+            reservations = reservations.subList(0, reservations.size() - 1); // 마지막 항목 제외
+            lastId = reservations.get(reservations.size() - 1).getId(); // 마지막 항목의 ID를 커서로 설정
+        }
+        List<ReservationResponseDTO.ReservationPreViewDTO> list = reservations
+                .stream()
+                .map(ReservationConverter::reservationPreViewDTO)
+                .collect(Collectors.toList());
+
+        return ReservationConverter.reservationPreViewListDTO(list, hasNext, lastId);
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Ticket/entity/Ticket.java
+++ b/src/main/java/com/acc/somsomparty/domain/Ticket/entity/Ticket.java
@@ -1,0 +1,33 @@
+package com.acc.somsomparty.domain.Ticket.entity;
+
+import com.acc.somsomparty.domain.Festival.entity.Festival;
+import com.acc.somsomparty.domain.Reservation.entity.Reservation;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Ticket {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "festival_id")
+    private Festival festival;
+    @Column(name = "festival_date", nullable = false)
+    private LocalDate festivalDate;
+    @Column(name = "total_tickets", nullable = false)
+    private Integer totalTickets;
+    @Setter
+    @Column(name = "left_tickets", nullable = false)
+    private Integer leftTickets;
+    @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL)
+    private List<Reservation> reservationList = new ArrayList<>();
+}

--- a/src/main/java/com/acc/somsomparty/domain/Ticket/repository/TicketRepository.java
+++ b/src/main/java/com/acc/somsomparty/domain/Ticket/repository/TicketRepository.java
@@ -1,0 +1,18 @@
+package com.acc.somsomparty.domain.Ticket.repository;
+
+import com.acc.somsomparty.domain.Ticket.entity.Ticket;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM Ticket t WHERE t.festival.id = :festivalId AND t.festivalDate = :festivalDate")
+    Optional<Ticket> findByFestivalIdAndFestivalDateWithLock(@Param("festivalId") Long festivalId,
+                                                             @Param("festivalDate") LocalDate festivalDate);
+}

--- a/src/main/java/com/acc/somsomparty/domain/User/repository/UserRepository.java
+++ b/src/main/java/com/acc/somsomparty/domain/User/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.acc.somsomparty.domain.User.repository;
+
+import com.acc.somsomparty.domain.User.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/acc/somsomparty/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/acc/somsomparty/global/exception/error/ErrorCode.java
@@ -16,7 +16,12 @@ public enum ErrorCode {
     FESTIVAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 축제입니다."),
     // Queue
     QUEUE_ALREADY_REGISTERED_USER(HttpStatus.CONFLICT, "이미 큐에 등록된 유저입니다."),
-    LOCK_ACQUISITION_FAILED(HttpStatus.BAD_REQUEST, "락을 획득할 수 없습니다.");
+    LOCK_ACQUISITION_FAILED(HttpStatus.BAD_REQUEST, "락을 획득할 수 없습니다."),
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    // Ticket
+    TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 티켓입니다."),
+    TICKET_SOLD_OUT(HttpStatus.BAD_REQUEST, "남아있는 티켓이 없습니다.");
 
     private final HttpStatus httpStatus;    // HttpStatus
     private final String message;       // 설명

--- a/src/test/java/com/acc/somsomparty/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/acc/somsomparty/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,120 @@
+package com.acc.somsomparty.reservation.service;
+
+import com.acc.somsomparty.domain.Queue.service.UserQueueService;
+import com.acc.somsomparty.domain.Reservation.dto.ReservationRequestDTO;
+import com.acc.somsomparty.domain.Reservation.repository.ReservationRepository;
+import com.acc.somsomparty.domain.Reservation.service.ReservationQueryService;
+import com.acc.somsomparty.domain.Ticket.entity.Ticket;
+import com.acc.somsomparty.domain.Ticket.repository.TicketRepository;
+import com.acc.somsomparty.global.exception.CustomException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class ReservationServiceTest {
+    @Autowired
+    private ReservationQueryService reservationQueryService;     // 예매 서비스
+    @Autowired
+    private ReservationRepository reservationRepository; // 예약 테이블
+    @Autowired
+    private UserQueueService userQueueService;
+//    @Autowired
+//    private ReservationCommandService reservationCommandService;
+
+
+//    @Test
+//    void 티켓_동시_예매_테스트() throws InterruptedException {
+//        // given
+//        int memberCount = 30;
+//        int ticketAmount = 10;
+//
+//
+//        ExecutorService executorService = Executors.newFixedThreadPool(30);
+//        CountDownLatch latch = new CountDownLatch(memberCount);
+//
+//        AtomicInteger successCount = new AtomicInteger();
+//        AtomicInteger failCount = new AtomicInteger();
+//        ReservationRequestDTO.makeReservationDTO dto = ReservationRequestDTO.makeReservationDTO.builder()
+//                .userId(1L)
+//                .festivalId(1L)
+//                .festivalDate(LocalDate.now())
+//                .build();
+//        // when
+//        for (int i = 0; i < memberCount; i++) {
+//            executorService.submit(() -> {
+//                try {
+//                    reservationCommandService.makeReservation(dto);
+//                    System.out.println(dto);
+//                    successCount.incrementAndGet();
+//                } catch (Exception e) {
+//                    System.out.println(e.getMessage());
+//                    failCount.incrementAndGet();
+//                } finally {
+//                    latch.countDown();
+//                }
+//            });
+//        }
+//
+//        latch.await();
+//
+//        System.out.println("successCount = " + successCount);
+//        System.out.println("failCount = " + failCount);
+//
+//    }
+
+    @Test
+    void 쿠폰차감_분산락_적용_동시성100명_테스트() throws InterruptedException, ExecutionException {
+
+        int numberOfThreads = 50;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        List<Callable<String>> tasks = new ArrayList<>();
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            tasks.add(() -> {
+                try {
+                    // 로그 추
+
+                    // 분산락 적용 메서드 호출
+                    userQueueService.allowUser("festival1", 3L);
+                    return "Success";
+                } catch(CustomException e){
+                    return "CustomException: " + e.getMessage();
+                }
+            });
+        }
+
+// 10개의 스레드 실행
+        List<Future<String>> results = executorService.invokeAll(tasks);
+
+        // 결과 확인
+        int successCount = 0;
+        int failureCount = 0;
+        int customExceptionCount = 0;
+
+
+        for (Future<String> result : results) {
+            String res = result.get();
+            if (res.startsWith("Success")) {
+                successCount++;
+            } else {
+                failureCount++;
+                if (res.startsWith("CustomException")) {
+                    customExceptionCount++;
+                }
+            }
+            System.out.println(res);
+        }
+        executorService.shutdown();
+    }
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #11 

## 📝 작업 내용
- 예약하기, 예약 목록 조회 API를 구현했습니다.
- 비관적 락을 사용해 티켓 엔티티에 대한 동시 접근을 제어하였습니다.
- 예약 상태, 인원수 컬럼은 불필요하다고 생각하여 제거하였습니다.

## 💬 리뷰 요구사항
> 전체적으로 코드 봐주시면 감사하겠습니다.
