### PR TITLE
Feature/ 내 예약 조회 responseDTO에 축제일 필드 추가

### DIFF
--- a/src/main/java/com/acc/somsomparty/domain/Festival/entity/Festival.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/entity/Festival.java
@@ -26,13 +26,13 @@ public class Festival extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String name;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 255)
     private String description;
 
     @Column(name = "name_lower", nullable = false, length = 20)
     private String nameLower;
 
-    @Column(name = "description_lower", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "description_lower", nullable = false, length = 255)
     private String descriptionLower;
 
     @Column(name = "start_date", nullable = false)

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/converter/ReservationConverter.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/converter/ReservationConverter.java
@@ -15,6 +15,7 @@ public class ReservationConverter {
         return ReservationResponseDTO.ReservationPreViewDTO.builder()
                 .id(reservation.getId())
                 .reservationDate(reservation.getReservationDate())
+                .festivalDate(reservation.getTicket().getFestivalDate())
                 .festivalInfo(FestivalConverter.festivalPreViewDTO(reservation.getTicket().getFestival()))
                 .build();
     }

--- a/src/main/java/com/acc/somsomparty/domain/Reservation/dto/ReservationResponseDTO.java
+++ b/src/main/java/com/acc/somsomparty/domain/Reservation/dto/ReservationResponseDTO.java
@@ -18,6 +18,7 @@ public class ReservationResponseDTO {
     public static class ReservationPreViewDTO {
         Long id;
         LocalDate reservationDate;
+        LocalDate festivalDate;
         FestivalResponseDTO.FestivalPreViewDTO festivalInfo;
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #

## 📝 작업 내용
- 내 예약 조회 responseDTO에 축제일(Ticket의 festivalDate) 필드 추가하였습니다. 
- Text 타입은 MySQL에서 인덱스를 지원하지 않아, Festival 엔티티의 description 컬럼을 VARCHAR(255)로 변경했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요