### PR TITLE
Feature/ 축제 생성 시 날짜별 티켓 생성, Redis 캐시 무효화

### DIFF
--- a/src/main/java/com/acc/somsomparty/domain/Festival/service/FestivalQueryServiceImpl.java
+++ b/src/main/java/com/acc/somsomparty/domain/Festival/service/FestivalQueryServiceImpl.java
@@ -99,6 +99,11 @@ public class FestivalQueryServiceImpl implements FestivalQueryService {
 
         Festival savedFestival = festivalRepository.save(festival);
         chattingService.publishCreateChatRoom(savedFestival);
+
+        // Redis 캐시 무효화
+        String cacheKeyPattern = "festival::search::*";
+        redisTemplate.keys(cacheKeyPattern).forEach(redisTemplate::delete);
+
         return savedFestival;
     }
 

--- a/src/main/java/com/acc/somsomparty/domain/Ticket/entity/Ticket.java
+++ b/src/main/java/com/acc/somsomparty/domain/Ticket/entity/Ticket.java
@@ -2,6 +2,7 @@ package com.acc.somsomparty.domain.Ticket.entity;
 
 import com.acc.somsomparty.domain.Festival.entity.Festival;
 import com.acc.somsomparty.domain.Reservation.entity.Reservation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,16 +19,22 @@ public class Ticket {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "festival_id")
     private Festival festival;
+
     @Column(name = "festival_date", nullable = false)
     private LocalDate festivalDate;
+
     @Column(name = "total_tickets", nullable = false)
     private Integer totalTickets;
+
     @Setter
     @Column(name = "left_tickets", nullable = false)
     private Integer leftTickets;
+
     @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL)
     private List<Reservation> reservationList = new ArrayList<>();
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #

## 📝 작업 내용
-   [feat: 축제 생성 시 날짜별 티켓 생성](https://github.com/SomSomParty/SomSomParty_BE/commit/5f6f13dbea29a811565bbf135f8686363e694cc2)
- [fix: 순환 참조 문제 해결](https://github.com/SomSomParty/SomSomParty_BE/commit/fec45a35bd1c7abf115ae073dbec1fde4f12e476)
- [feat: 축제 생성 시 Redis 캐시 무효화](https://github.com/SomSomParty/SomSomParty_BE/commit/76e73a72c0b7f4076802dbcb68eb02e69dc5b976)
## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
티켓 생성 로직이 없길래 추가해두었습니다. 티켓 수(defaultTotalTickets)는 원하는 대로 변경하시면 될 것 같습니다. 