### PR TITLE
Feature/#27 FCM 토큰 관리 API 추가 및 알림 전송 보완

### DIFF
--- a/src/main/java/com/acc/somsomparty/domain/Notification/controller/NotificationController.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/controller/NotificationController.java
@@ -1,0 +1,37 @@
+package com.acc.somsomparty.domain.Notification.controller;
+
+import com.acc.somsomparty.domain.Notification.dto.FcmTokenActivateRequest;
+import com.acc.somsomparty.domain.Notification.dto.FcmTokenDeactivateRequest;
+import com.acc.somsomparty.domain.Notification.service.FcmTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+    private final FcmTokenService fcmTokenService;
+
+    @Operation(
+            summary = "FCM 토큰 활성화",
+            description = "FCM 토큰과 디바이스 정보를 받아 해당 토큰을 활성화합니다."
+    )
+    @PostMapping("/notification/activate")
+    public ResponseEntity<String> activateFcmToken(@RequestBody FcmTokenActivateRequest req) {
+        fcmTokenService.activateFcmToken(req.getToken(), req.getDeviceType());
+        return ResponseEntity.ok("FCM 토큰이 활성화되었습니다.");
+    }
+
+    @Operation(
+            summary = "FCM 토큰 비활성화",
+            description = "FCM 토큰 정보를 받아 해당 토큰을 비활성화합니다."
+    )
+    @PostMapping("/notification/deactivate")
+    public ResponseEntity<String> deactivateFcmToken(@RequestBody FcmTokenDeactivateRequest req) {
+        fcmTokenService.deactivateFcmToken(req.getToken());
+        return ResponseEntity.ok("FCM 토큰이 활성화되었습니다.");
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Notification/dto/FcmTokenActivateRequest.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/dto/FcmTokenActivateRequest.java
@@ -1,0 +1,10 @@
+package com.acc.somsomparty.domain.Notification.dto;
+
+import com.acc.somsomparty.domain.Notification.enums.DeviceType;
+import lombok.Getter;
+
+@Getter
+public class FcmTokenActivateRequest {
+    private String token;
+    private DeviceType deviceType;
+}

--- a/src/main/java/com/acc/somsomparty/domain/Notification/dto/FcmTokenDeactivateRequest.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/dto/FcmTokenDeactivateRequest.java
@@ -1,0 +1,8 @@
+package com.acc.somsomparty.domain.Notification.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FcmTokenDeactivateRequest {
+    private String token;
+}

--- a/src/main/java/com/acc/somsomparty/domain/Notification/entity/FcmToken.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/entity/FcmToken.java
@@ -1,6 +1,7 @@
 package com.acc.somsomparty.domain.Notification.entity;
 
 import com.acc.somsomparty.domain.Notification.enums.DeviceType;
+import com.acc.somsomparty.domain.Notification.enums.TokenState;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -31,4 +32,7 @@ public class FcmToken {
     private LocalDateTime updatedDate;   // fcm 토큰 갱신 날짜
 
     private Long userId;  // user 정보
+
+    @Enumerated(EnumType.STRING)
+    private TokenState tokenState;
 }

--- a/src/main/java/com/acc/somsomparty/domain/Notification/enums/TokenState.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/enums/TokenState.java
@@ -1,0 +1,5 @@
+package com.acc.somsomparty.domain.Notification.enums;
+
+public enum TokenState {
+    Enabled, Disabled
+}

--- a/src/main/java/com/acc/somsomparty/domain/Notification/projection/FestivalTokenProjection.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/projection/FestivalTokenProjection.java
@@ -1,8 +1,10 @@
 package com.acc.somsomparty.domain.Notification.projection;
 
 import com.acc.somsomparty.domain.Festival.entity.Festival;
+import com.acc.somsomparty.domain.Notification.enums.TokenState;
 
 public interface FestivalTokenProjection {
     String getFcmToken();
+    TokenState getTokenState();
     Festival getFestival();
 }

--- a/src/main/java/com/acc/somsomparty/domain/Notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/repository/FcmTokenRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Repository
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     // 축제 시작 날짜를 기준으로 예약자의 fcm token 가져오기
-    @Query("SELECT ft.fcmToken AS fcmToken, f AS festival " +
+    @Query("SELECT ft.fcmToken AS fcmToken, ft.tokenState AS tokenState, f AS festival " +
             "FROM FcmToken ft " +
             "JOIN Reservation r ON ft.userId = r.user.id " +
             "JOIN Ticket t ON r.ticket.id = t.id " +

--- a/src/main/java/com/acc/somsomparty/domain/Notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/repository/FcmTokenRepository.java
@@ -20,4 +20,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
             "JOIN Festival f ON t.festival.id = f.id " +
             "WHERE f.startDate = :tomorrow")
     List<FestivalTokenProjection> findTokensForTomorrowFestival(@Param("tomorrow") LocalDate tomorrow);
+
+    FcmToken findByFcmTokenAndUserId(String fcmToken, Long userId);
 }

--- a/src/main/java/com/acc/somsomparty/domain/Notification/service/FcmTokenService.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/service/FcmTokenService.java
@@ -1,0 +1,8 @@
+package com.acc.somsomparty.domain.Notification.service;
+
+import com.acc.somsomparty.domain.Notification.enums.DeviceType;
+
+public interface FcmTokenService {
+    void activateFcmToken(String token, DeviceType deviceType);
+    void deactivateFcmToken(String token);
+}

--- a/src/main/java/com/acc/somsomparty/domain/Notification/service/FcmTokenServiceImpl.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/service/FcmTokenServiceImpl.java
@@ -1,0 +1,56 @@
+package com.acc.somsomparty.domain.Notification.service;
+
+import com.acc.somsomparty.domain.Notification.entity.FcmToken;
+import com.acc.somsomparty.domain.Notification.enums.DeviceType;
+import com.acc.somsomparty.domain.Notification.enums.TokenState;
+import com.acc.somsomparty.domain.Notification.repository.FcmTokenRepository;
+import com.acc.somsomparty.domain.User.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmTokenServiceImpl implements FcmTokenService {
+    private final FcmTokenRepository fcmTokenRepository;
+    private final UserService userService;
+
+    public void activateFcmToken(String token, DeviceType deviceType) {
+        Long userId = userService.getIdByAuthentication();
+        log.info("Activating FCM token. User ID: {}, Token: {}, Device Type: {}", userId, token, deviceType);
+
+        FcmToken fcmToken = fcmTokenRepository.findByFcmTokenAndUserId(token, userId);
+
+        if (fcmToken == null) {
+            log.info("No existing FCM token found. Creating new token for User ID: {}", userId);
+            fcmToken = FcmToken.builder()
+                    .userId(userId)
+                    .fcmToken(token)
+                    .deviceType(deviceType)
+                    .tokenState(TokenState.Enabled)
+                    .build();
+        } else {
+            log.info("Existing FCM token found for User ID: {}. Updating token state to Enabled.", userId);
+            fcmToken.setTokenState(TokenState.Enabled);
+        }
+        fcmTokenRepository.save(fcmToken);
+        log.info("FCM token successfully activated for User ID: {}", userId);
+    }
+
+    public void deactivateFcmToken(String token) {
+        Long userId = userService.getIdByAuthentication();
+        log.info("Deactivating FCM token. User ID: {}, Token: {}", userId, token);
+
+        FcmToken fcmToken = fcmTokenRepository.findByFcmTokenAndUserId(token, userId);
+
+        if (fcmToken != null) {
+            log.info("Existing FCM token found for User ID: {}. Updating token state to Disabled.", userId);
+            fcmToken.setTokenState(TokenState.Disabled);
+            fcmTokenRepository.save(fcmToken);
+            log.info("FCM token successfully deactivated for User ID: {}", userId);
+        } else {
+            log.warn("No FCM token found for User ID: {} and Token: {}. Nothing to deactivate.", userId, token);
+        }
+    }
+}

--- a/src/main/java/com/acc/somsomparty/domain/Notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/acc/somsomparty/domain/Notification/service/NotificationServiceImpl.java
@@ -1,6 +1,8 @@
 package com.acc.somsomparty.domain.Notification.service;
 
 import com.acc.somsomparty.domain.Festival.entity.Festival;
+import com.acc.somsomparty.domain.Notification.entity.FcmToken;
+import com.acc.somsomparty.domain.Notification.enums.TokenState;
 import com.acc.somsomparty.domain.Notification.projection.FestivalTokenProjection;
 import com.acc.somsomparty.domain.Notification.repository.FcmTokenRepository;
 import lombok.RequiredArgsConstructor;
@@ -50,10 +52,16 @@ public class NotificationServiceImpl implements NotificationService {
 
             for (FestivalTokenProjection projection : results) {
                 String token = projection.getFcmToken();
+                TokenState tokenState = projection.getTokenState();
                 Festival festival = projection.getFestival();
 
                 if (token == null || token.isEmpty()) {
                     logger.warn("FCM token is missing for festival: {}", festival.getName());
+                    continue;
+                }
+
+                if (tokenState == TokenState.Disabled) {
+                    logger.warn("FCM token is disabled for festival: {}", festival.getName());
                     continue;
                 }
 

--- a/src/main/java/com/acc/somsomparty/global/config/SecurityConfig.java
+++ b/src/main/java/com/acc/somsomparty/global/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         // .requestMatchers("/test").authenticated()
+                        .requestMatchers("/notification/*").authenticated()
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #27 

## 📝 작업 내용
-   FCM 토큰 관리 관련 API를 구현하고, 알림 전송을 보완하였습니다. 
    - FCM 토큰 저장 및 활성화 API 구현
    - FCM 토큰 비활성화 API 구현 
    - FCM 토큰이 비활성화 상태일 때 푸시 알림이 전송되지 않도록 보완

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
